### PR TITLE
fix: file already exists error on Linux

### DIFF
--- a/pack/helpers.py
+++ b/pack/helpers.py
@@ -39,3 +39,16 @@ def add_affixes(file: str, prefix: str = "", suffix: str = "") -> str:
     path = Path(file)
     new_file_name = f"{prefix}{path.stem}{suffix}{path.suffix}"
     return str(path.with_name(new_file_name))
+
+
+def file_exists(file: str) -> bool:
+    """
+    Check if a file exists.
+
+    Args:
+        file (str): The path to the file.
+
+    Returns:
+        bool: True if the file exists, False otherwise.
+    """
+    return Path(file).exists()

--- a/pack/utils.py
+++ b/pack/utils.py
@@ -1,7 +1,8 @@
 from ffmpeg_progress_yield import FfmpegProgress
+from rich.console import Console
 from rich.progress import Progress
 
-from .helpers import add_affixes
+from .helpers import add_affixes, file_exists
 
 
 def compress_video(
@@ -24,6 +25,15 @@ def compress_video(
         pass
     else:
         output = add_affixes(input_file, suffix="_compressed")
+
+    if file_exists(output) and not override:
+        console = Console()
+        console.print(
+            f" [Skipped][{output}][Already exists]",
+            style="bold green",
+            markup=False,
+        )
+        return
 
     command = [
         "ffmpeg",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,8 +1,9 @@
 import subprocess
+from unittest.mock import patch
 
 import pytest
 
-from pack.helpers import add_affixes, is_ffmpeg_installed
+from pack.helpers import add_affixes, file_exists, is_ffmpeg_installed
 
 
 @pytest.mark.parametrize(
@@ -48,3 +49,17 @@ def test_ffmpeg_not_installed(monkeypatch):
     monkeypatch.setattr(subprocess, "run", mock_run)
 
     assert is_ffmpeg_installed() is False
+
+
+@patch("pack.helpers.Path.exists")
+def test_file_exists(mock_exists):
+    """
+    Test file_exists function with different scenarios.
+    """
+    # Simulate that the file exists
+    mock_exists.return_value = True
+    assert file_exists("/path/to/existing_file.txt") is True
+
+    # Simulate that the file does not exist
+    mock_exists.return_value = False
+    assert file_exists("/path/to/non_existent_file.txt") is False


### PR DESCRIPTION
Prevented errors on Linux with the '-n' (no overwrite) option in ffmpeg when the output file exists; no error occurs on macOS.

- macOS

![image](https://github.com/user-attachments/assets/a5dbc85b-a45b-4a3c-a8c7-c9bf1ab206c8)

- Linux (ERROR)

![image](https://github.com/user-attachments/assets/08ab93a7-2c0c-4291-ad29-b12690f7d6c2)
![image](https://github.com/user-attachments/assets/c6529da6-1366-4795-855a-3106f06c9b4f)
