### PR TITLE
feat: add video quality control

### DIFF
--- a/pack/cli.py
+++ b/pack/cli.py
@@ -31,6 +31,13 @@ def main(
             help=Constants.OUTPUT_HELP_TEXT,
         ),
     ] = None,
+    quality: Annotated[
+        int,
+        typer.Option(
+            show_default=True,
+            help=Constants.QUALITY_HELP_TEXT,
+        ),
+    ] = 75,
     overwrite: Annotated[
         bool,
         typer.Option(
@@ -69,7 +76,12 @@ def main(
                 style="green",
                 markup=False,
             )
-            compress_video(input_file=input, output_file=output, overwrite=overwrite)
+            compress_video(
+                input_file=input,
+                output_file=output,
+                overwrite=overwrite,
+                quality=quality,
+            )
             if delete_original:
                 delete_path(input)
         except FFmpegError as e:
@@ -102,6 +114,7 @@ def main(
                 compress_video(
                     input_file=video_path,
                     overwrite=overwrite,
+                    quality=quality,
                 )
                 if delete_original:
                     delete_path(video_path)

--- a/pack/constants.py
+++ b/pack/constants.py
@@ -5,6 +5,7 @@ class Constants:
     DEBUG_HELP_TEXT = "Enable debugging."
     DELETE_ORIGINAL_HELP_TEXT = "Delete the original video after compression."
     OVERWRITE_HELP_TEXT = "Overwrite existing output file."
+    QUALITY_HELP_TEXT = "Video quality level from range [0, 100]. Default is 75. Lower values mean (lower quality, higher compression). Higher values mean (higher quality, lower compression)."
     UTILS_PANEL_TEXT = "Customization and Utils"
     ERROR_MESSAGE = "An error occurred while compressing the video 💥."
     UNKNOWN_ERROR_MESSAGE = "An unknown error occurred 💥."

--- a/pack/core.py
+++ b/pack/core.py
@@ -6,6 +6,7 @@ from rich.progress import Progress as ProgressBar
 
 from .constants import Constants
 from .helpers import add_affixes
+from .utils import convert_quality_to_crf
 
 
 def _rethrow_ffmpeg_error(error: FFmpegError) -> None:
@@ -61,6 +62,7 @@ def compress_video(
     input_file: str,
     output_file: str | None = None,
     overwrite: bool = False,
+    quality: int = 75,
 ):
     """
     Compress a video file using FFmpeg and display the progress in a terminal.
@@ -78,11 +80,18 @@ def compress_video(
     else:
         output = add_affixes(input_file, suffix=Constants.COMPRESSED_SUFFIX)
 
+    crf = convert_quality_to_crf(quality)
+
     ffmpeg = (
         FFmpeg()
         .option("y" if overwrite else "n")
         .input(input_file)
-        .output(output, vcodec="h264", acodec="aac")
+        .output(
+            output,
+            vcodec="h264",
+            acodec="aac",
+            crf=crf,
+        )
     )
 
     with ProgressBar() as progress_bar:

--- a/pack/utils.py
+++ b/pack/utils.py
@@ -25,3 +25,19 @@ def list_unprocessed_videos(
                 if not Path(file).stem.endswith(skip_suffix):
                     videos.append(os.path.join(root, file))
     return videos
+
+
+def convert_quality_to_crf(quality: int) -> int:
+    """
+    Convert a quality level from range [0, 100] to a Constant Rate Factor (CRF)
+    value in range [23, 51]. Lower values mean (lower quality, higher compression).
+    Higher values mean (higher quality, lower compression).
+
+    Args:
+        quality (int): The quality level to convert.
+
+    Returns:
+        int: The CRF value.
+    """
+    c, q = 51 - 23, 100 - 0
+    return int(51 - quality * (c / q))


### PR DESCRIPTION
Adds a new `quality` option to allow users to control the output video quality.

The quality level is a number between 0 and 100, where a lower number means higher compression and lower quality, and a higher number means lower compression and higher quality. The default quality level is 75.